### PR TITLE
Create a default security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+Contact: cybersecurity@crowncommercial.gov.uk
+
+Policy: https://www.crowncommercial.gov.uk/about-ccs/vulnerability-disclosure-policy
+
+Acknowledgements: https://github.com/Crown-Commercial-Service/ccs-vulnerability-disclosure-policy/blob/main/acknowledgements.txt
+
+Encryption: https://github.com/Crown-Commercial-Service/ccs-vulnerability-disclosure-policy/blob/main/vulnerability-disclosure-public-encryption.pub


### PR DESCRIPTION
This security policy will apply to all repos that haven't set their own policy - see https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file.

This should make it much easier to manage our security policy. We have over 100 repos in our organisation, and having to set the security policy for each individually would be really rather time-consuming.

This is a copy of the authoritative version maintained by @ramya-chan and co.: https://github.com/Crown-Commercial-Service/ccs-vulnerability-disclosure-policy/blob/main/security.txt